### PR TITLE
Inline with original API

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,19 @@ pokerEvaluator.evalHand(['As', 'Ac', 'Qs']);
 //  handName: 'one pair' }
 ```
 
+Alternatively using the original API (less recommended):
+
+```js
+const PokerEvaluator = require("poker-evaluator");
+
+PokerEvaluator.evalHand(["As", "Ks", "Qs", "Js", "Ts", "3c", "5h"]);
+
+PokerEvaluator.evalHand(["As", "Ac", "Ad", "5d", "5s"]);
+
+PokerEvaluator.evalHand(["As", "Ac", "Qs"]);
+
+```
+
 The returned object is an `EvaluatedHand` (src/types/evaluated-hand.interface.ts). An explanation of its properties is as follows:  
 ```ts
 handType: number; // Index of the HAND_TYPES array  

--- a/README.md
+++ b/README.md
@@ -58,13 +58,25 @@ pokerEvaluator.evalHand(['As', 'Ac', 'Qs']);
 Alternatively using the original API (less recommended):
 
 ```js
-const PokerEvaluator = require("poker-evaluator");
+const PokerEvaluator = require('poker-evaluator');
 
-PokerEvaluator.evalHand(["As", "Ks", "Qs", "Js", "Ts", "3c", "5h"]);
+PokerEvaluator.evalHand(['As', 'Ks', 'Qs', 'Js', 'Ts', '3c', '5h']);
+//{ handType: 9,
+//  handRank: 10,
+//  value: 36874,
+//  handName: 'straight flush' }
 
-PokerEvaluator.evalHand(["As", "Ac", "Ad", "5d", "5s"]);
+```
 
-PokerEvaluator.evalHand(["As", "Ac", "Qs"]);
+With numbers: 
+```js
+const PokerEvaluator = require('poker-evaluator');
+
+PokerEvaluator.evalHand([17, 22, 27, 32, 33]);
+//{ handType: 5,
+//  handRank: 6,
+//  value: 20486,
+//  handName: 'straight' }
 
 ```
 

--- a/src/poker-evaluator.ts
+++ b/src/poker-evaluator.ts
@@ -8,6 +8,11 @@ import ThreeCardConverter from './three-card-converter';
 // This is outside the class so evalHand is static, to keep same api as @chenosaurus/poker-evaluator
 const RANKS_DATA = fs.readFileSync(path.join(__dirname, '../data/HandRanks.dat'));
 
+// Create a wrapper function to keep same api as @chenosaurus/poker-evaluator
+export function evalHand(cards: string[] | number[]) {
+  return PokerEvaluator.evalHand(cards);
+}
+
 export class PokerEvaluator {
   public static evalHand(cards: string[] | number[]): EvaluatedHand {
     if (!RANKS_DATA) {


### PR DESCRIPTION
Hi rory, I tested your changes and everything looked really good. 

One thing I noticed is that the current code isn't quite inline with the old api. Currently you have to do this:
```js
const evaluator = require('poker-evaluator');
evaluator.PokerEvaluator.evalHand(["As", "Ks", "Qs", "Js", "Ts", "3c", "5h"];
```
I added a wrapper function to the static function of the class. Now you can do this:
```js
const evaluator = require('poker-evaluator');
evaluator.evalHand(["As", "Ks", "Qs", "Js", "Ts", "3c", "5h"];
```
This is inline with the existing API.

Asides that it seems great!
